### PR TITLE
Associative choice with identity.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 2.1.0
+
+Deprecated `L.firstOf` and added `L.choice`, `L.nothing` and `L.orElse` that
+allows the same (and more) functionality to be expressed more compositionally.
+
 ## 2.0.0
 
 Changed from using a single default export to named exports to support dead-code

--- a/README.md
+++ b/README.md
@@ -472,7 +472,7 @@ L.over(majorAxis, R.negate, {x: 2, y: -3})
 // { y: 3, x: 2 }
 ```
 
-#### [`L.choice(...ls)`](#lchoice-ls "L.choice :: (...PLens s a) -> PLens s a")
+#### [`L.choice(...ls)`](#lchoicels "L.choice :: (...PLens s a) -> PLens s a")
 
 `L.choice(...ls)` returns a partial lens that acts like the first of the given
 lenses, `...ls`, whose view is not undefined on the given target.  When the

--- a/README.md
+++ b/README.md
@@ -472,6 +472,13 @@ L.over(majorAxis, R.negate, {x: 2, y: -3})
 // { y: 3, x: 2 }
 ```
 
+#### [`L.choice(...ls)`](#lchoice-ls "L.choice :: (...PLens s a) -> PLens s a")
+
+`L.choice(...ls)` returns a partial lens that acts like the first of the given
+lenses, `...ls`, whose view is not undefined on the given target.  When the
+views of all of the given lenses are undefined, the returned lens acts like
+`L.nothing`, which is the identity element of `L.choice`.
+
 #### [`L.compose(l, ...ls)`](#lcomposel-ls "L.compose :: (PLens s s1, ...PLens sN a) -> PLens s a")
 
 The default import `P(l, ...ls)` and `L.compose(l, ...ls)` both are the same as
@@ -559,6 +566,8 @@ L.set(L.findWith("x"), 3, [{z: 6}, {x: 9}, {y: 6}])
 
 #### [`L.firstOf(l, ...ls)`](#lfirstofl-ls "L.firstOf :: (PLens s a, ...PLens s a) -> PLens s a")
 
+**`L.firstOf` is deprecated and will be removed. See `L.choice` and `L.orElse`.**
+
 `L.firstOf(l, ...ls)` returns a partial lens that acts like the first of the
 given lenses, `l, ...ls`, whose view is not undefined on the given target.  When
 the views of all of the given lenses are undefined, the returned lens acts like
@@ -632,6 +641,25 @@ const toPartial = transform => x => undefined === x ? x : transform(x)
 The main use case for `normalize` is to make it easy to determine whether, after
 a change, the data has actually changed.  By keeping the data normalized, a
 simple `R.equals` comparison will do.
+
+#### [`L.nothing`](#lnothing "L.nothing :: PLens s s")
+
+`L.nothing` is a special lens whose view is always undefined and setting through
+`L.nothing` has no effect.  In other words, for all `x` and `y`:
+
+```js
+  L.view(L.nothing, x) = undefined
+L.set(L.nothing, y, x) = x
+```
+
+`L.nothing` is the identity element of `L.choice`.
+
+#### [`L.orElse(backup, primary)`](#lorelsebackup-primary "L.orElse :: (PLens s a, PLens s a) -> PLens s a")
+
+`L.orElse(backup, primary)` acts like `primary` when its view is not undefined
+and otherwise like `backup`.  You can use `L.orElse` on its own with
+`R.reduceRight` (and `R.reduce`) to create an associative choice over lenses or
+use `L.orElse` to specify a default or backup lens for `L.choice`, for example.
 
 #### [`L.pick({p1: l1, ...pls})`](#lpickp1-l1-pls "L.pick :: {p1 :: PLens s a1, ...pls} -> PLens s {p1 :: a1, ...pls}")
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "partial.lenses",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "Ramda compatible partial lenses",
   "main": "lib/partial.lenses.js",
   "scripts": {
@@ -28,13 +28,13 @@
     "ramda": "^0.20.1"
   },
   "devDependencies": {
-    "babel-cli": "^6.6.5",
+    "babel-cli": "^6.7.5",
     "babel-eslint": "^6.0.2",
     "babel-plugin-transform-es2015-modules-commonjs": "^6.7.4",
     "babel-preset-es2015": "^6.6.0",
     "babel-preset-stage-2": "^6.5.0",
     "eslint": "^2.7.0",
     "mocha": "^2.4.5",
-    "nyc": "^6.1.1"
+    "nyc": "^6.2.1"
   }
 }

--- a/test/tests.js
+++ b/test/tests.js
@@ -27,6 +27,7 @@ describe("default === compose", () => {
 
 describe("arities", () => {
   testEq('L.augment.length', 1)
+  testEq('L.choice.length', 0)
   testEq('L.compose.length', 0)
   testEq('L.defaults.length', 1)
   testEq('L.define.length', 1)
@@ -36,6 +37,7 @@ describe("arities", () => {
   testEq('L.index.length', 1)
   testEq('L.lens.length', 2)
   testEq('L.normalize.length', 1)
+  testEq('L.orElse.length', 2)
   testEq('L.over.length', 3)
   testEq('L.pick.length', 1)
   testEq('L.prop.length', 1)
@@ -109,6 +111,27 @@ describe("L.normalize", () => {
          undefined)
   testEq('L.set(P(L.normalize(R.sortBy(R.identity)), L.find(R.equals(2))), undefined, [1,3,2,5])',
          [1,3,5])
+})
+
+describe("L.nothing", () => {
+  testEq('L.view(L.nothing, "anything")', undefined)
+  testEq('L.set(L.nothing, "anything", "original")', "original")
+})
+
+describe("L.orElse", () => {
+  testEq('L.view(L.orElse("b", "a"), {a: 2, b: 1})', 2)
+  testEq('L.view(L.orElse("b", "a"), {b: 2})', 2)
+  testEq('L.set(L.orElse("b", "a"), 3, {a: 2, b: 1})', {a: 3, b: 1})
+  testEq('L.set(L.orElse("b", "a"), 3, {b: 2})', {b: 3})
+})
+
+describe("L.choice", () => {
+  testEq('L.view(L.choice("x", "y"), {x: "a"})', "a")
+  testEq('L.view(L.choice("x", "y"), {y: "b"})', "b")
+  testEq('L.view(L.choice("x", "y"), {z: "c"})', undefined)
+  testEq('L.set(L.choice("x", "y"), "A", {x: "a"})', {x: "A"})
+  testEq('L.set(L.choice("x", "y"), "B", {y: "b"})', {y: "B"})
+  testEq('L.set(L.choice("x", "y"), "C", {z: "c"})', {z: "c"})
 })
 
 describe("L.firstOf", () => {


### PR DESCRIPTION
This corrects the `L.firstOf` mistake where I didn't see the possibility
of a suitable identity element for choice.  `L.nothing` acts like the
identity element of `L.choice`.  `L.orElse` can be used to give a backup
or default if it is really needed, but none of the actual use cases I've
seen so far require a backup.