### PR TITLE
add .babelrc to npmignore to work under React Native

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,2 +1,3 @@
 !lib
 *~
+.babelrc

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "partial.lenses",
-  "version": "3.4.1",
+  "version": "3.4.2",
   "description": "Partial lenses",
   "main": "lib/partial.lenses.js",
   "scripts": {


### PR DESCRIPTION
React Native uses different babel settings