### PR TITLE
Specialize select over elems

### DIFF
--- a/src/partial.lenses.js
+++ b/src/partial.lenses.js
@@ -196,6 +196,15 @@ function force(x) {
   return x
 }
 
+function selectElems(xi2yA, xs) {
+  for (let i=0, n=xs.length, x; i<n; ++i) {
+    x = force(xi2yA(xs[i], i))
+    if (U !== x)
+      return x
+  }
+  return U
+}
+
 const Select = /*#__PURE__*/ConcatOf(
   (l, r) => void 0 !== (l = force(l)).v ? l : r,
   U,
@@ -849,9 +858,9 @@ export function branch(template) {
 
 export function elems(xs, _i, A, xi2yA) {
   if (seemsArrayLike(xs)) {
-    return A === Ident
-      ? mapPartialIndexU(xi2yA, xs)
-      : traversePartialIndex(A, xi2yA, xs)
+    return A === Ident  ? mapPartialIndexU(xi2yA, xs)
+      :    A === Select ? selectElems(xi2yA, xs)
+      :                   traversePartialIndex(A, xi2yA, xs)
   } else {
     if (process.env.NODE_ENV !== "production")
       reqApplicative(A, "elems")


### PR DESCRIPTION
This seems to roughly double the speed of `selectAs` over `elems`.  The
optimization applies to all current lazy folds.