### PR TITLE
Generalize `choice`, `orElse`, and `findWith`

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ parts.  [Try Lenses!](https://calmm-js.github.io/partial.lenses/playground.html)
       * [`L.compose(...optics) ~> optic`](#L-compose "L.compose: (POptic s s1, ...POptic sN a) -> POptic s a") or `[...optics]`
     * [Querying](#querying)
       * [`L.chain((value, index) => optic, optic) ~> optic`](#L-chain "L.chain: ((a, Index) -> POptic s b) -> POptic s a -> POptic s b")
-      * [`L.choice(...lenses) ~> optic`](#L-choice "L.choice: (...PLens s a) -> POptic s a")
+      * [`L.choice(...optics) ~> optic`](#L-choice "L.choice: (...POptic s a) -> POptic s a")
       * [`L.choose((maybeValue, index) => optic) ~> optic`](#L-choose "L.choose: ((Maybe s, Index) -> POptic s a) -> POptic s a")
       * [`L.optional ~> optic`](#L-optional "L.optional: POptic a a")
       * [`L.when((maybeValue, index) => testable) ~> optic`](#L-when "L.when: ((Maybe a, Index) -> Boolean) -> POptic a a")
@@ -113,7 +113,7 @@ parts.  [Try Lenses!](https://calmm-js.github.io/partial.lenses/playground.html)
       * [`L.filter((maybeValue, index) => testable) ~> lens`](#L-filter "L.filter: ((Maybe a, Index) -> Boolean) -> PLens [a] [a]")
       * [`L.find((maybeValue, index) => testable) ~> lens`](#L-find "L.find: ((Maybe a, Index) -> Boolean) -> PLens [a] a")
       * [`L.findHint((maybeValue, {hint: index}) => testable, {hint: index}) ~> lens`](#L-findHint "L.findHint: ((Maybe a, {hint: Index}) -> Boolean, {hint: Index}) -> PLens [a] a")
-      * [`L.findWith(...lenses) ~> lens`](#L-findWith "L.findWith: (PLens s s1, ...PLens sN a) -> PLens [s] a")
+      * [`L.findWith(...optics) ~> lens`](#L-findWith "L.findWith: (POptic s s1, ...POptic sN a) -> POptic [s] a")
       * [`L.index(elemIndex) ~> lens`](#L-index "L.index: Integer -> PLens [a] a") or `elemIndex`
       * [`L.last ~> lens`](#L-last "L.last: PLens [a] a")
       * [`L.slice(maybeBegin, maybeEnd) ~> lens`](#L-slice "L.slice: Maybe Integer -> Maybe Integer -> PLens [a] [a]")
@@ -126,7 +126,7 @@ parts.  [Try Lenses!](https://calmm-js.github.io/partial.lenses/playground.html)
     * [Providing defaults](#providing-defaults)
       * [`L.valueOr(valueOut) ~> lens`](#L-valueOr "L.valueOr: s -> PLens s s")
     * [Adapting to data](#adapting-to-data)
-      * [`L.orElse(backupLens, primaryLens) ~> lens`](#L-orElse "L.orElse: (PLens s a, PLens s a) -> PLens s a")
+      * [`L.orElse(backupOptic, primaryOptic) ~> lens`](#L-orElse "L.orElse: (POptic s a, POptic s a) -> POptic s a")
     * [Transforming data](#transforming-data)
       * [`L.pick({prop: lens, ...props}) ~> lens`](#L-pick "L.pick: {p1: PLens s a1, ...pls} -> PLens s {p1: a1, ...pls}")
       * [`L.replace(maybeValueIn, maybeValueOut) ~> lens`](#L-replace "L.replace: Maybe s -> Maybe s -> PLens s s")
@@ -937,11 +937,11 @@ Note that with the [`R.always`](http://ramdajs.com/docs/#always),
 `L.chain`, [`L.choice`](#L-choice) and [`L.zero`](#L-zero) combinators, one can
 consider optics as subsuming the maybe monad.
 
-##### <a id="L-choice"></a> [≡](#contents) [▶](https://calmm-js.github.io/partial.lenses/#L-choice) [`L.choice(...lenses) ~> optic`](#L-choice "L.choice: (...PLens s a) -> POptic s a")
+##### <a id="L-choice"></a> [≡](#contents) [▶](https://calmm-js.github.io/partial.lenses/#L-choice) [`L.choice(...optics) ~> optic`](#L-choice "L.choice: (...POptic s a) -> POptic s a")
 
-`L.choice` returns a partial optic that acts like the first of the given lenses
+`L.choice` returns a partial optic that acts like the first of the given optics
 whose view is not `undefined` on the given data structure.  When the views of
-all of the given lenses are `undefined`, the returned lens acts
+all of the given optics are `undefined`, the returned optics acts
 like [`L.zero`](#L-zero), which is the identity element of `L.choice`.
 
 For example:
@@ -2147,11 +2147,11 @@ L.modify([L.findHint(R.whereEq({id: 2}), {hint: 2}), "value"],
 //  {id: 5, value: "e"}]
 ```
 
-##### <a id="L-findWith"></a> [≡](#contents) [▶](https://calmm-js.github.io/partial.lenses/#L-findWith) [`L.findWith(...lenses) ~> lens`](#L-findWith "L.findWith: (PLens s s1, ...PLens sN a) -> PLens [s] a")
+##### <a id="L-findWith"></a> [≡](#contents) [▶](https://calmm-js.github.io/partial.lenses/#L-findWith) [`L.findWith(...optics) ~> lens`](#L-findWith "L.findWith: (POptic s s1, ...POptic sN a) -> POptic [s] a")
 
-`L.findWith(...lenses)` chooses an index from an [array-like](#array-like)
-object through which the given lens, [`[...lenses]`](#L-compose), focuses on a
-defined item and then returns a lens that focuses on that item.
+`L.findWith(...optics)` chooses an index from an [array-like](#array-like)
+object through which the given optic, [`[...optics]`](#L-compose), has a
+non-`undefined` view and then returns an optic that focuses on that.
 
 For example:
 
@@ -2462,13 +2462,13 @@ L.remove(L.valueOr(0), 1)
 
 #### Adapting to data
 
-##### <a id="L-orElse"></a> [≡](#contents) [▶](https://calmm-js.github.io/partial.lenses/#L-orElse) [`L.orElse(backupLens, primaryLens) ~> lens`](#L-orElse "L.orElse: (PLens s a, PLens s a) -> PLens s a")
+##### <a id="L-orElse"></a> [≡](#contents) [▶](https://calmm-js.github.io/partial.lenses/#L-orElse) [`L.orElse(backupOptic, primaryOptic) ~> lens`](#L-orElse "L.orElse: (POptic s a, POptic s a) -> POptic s a")
 
-`L.orElse(backupLens, primaryLens)` acts like `primaryLens` when its view is not
-`undefined` and otherwise like `backupLens`.  You can use `L.orElse` on its own
-with [`R.reduceRight`](http://ramdajs.com/docs/#reduceRight)
+`L.orElse(backupOptic, primaryOptic)` acts like `primaryOptic` when its view is
+not `undefined` and otherwise like `backupOptic`.  You can use `L.orElse` on its
+own with [`R.reduceRight`](http://ramdajs.com/docs/#reduceRight)
 (and [`R.reduce`](http://ramdajs.com/docs/#reduce)) to create an associative
-choice over lenses or use `L.orElse` to specify a default or backup lens
+choice over optics or use `L.orElse` to specify a default or backup optic
 for [`L.choice`](#L-choice), for example.
 
 #### Transforming data

--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ parts.  [Try Lenses!](https://calmm-js.github.io/partial.lenses/playground.html)
       * [`L.countIf((maybeValue, index) => testable, traversal, maybeData) ~> number`](#L-countIf "L.countIf: ((Maybe a, Index) -> Boolean) -> PTraversal s a -> Number")
       * [`L.foldl((value, maybeValue, index) => value, value, traversal, maybeData) ~> value`](#L-foldl "L.foldl: ((r, Maybe a, Index) -> r) -> r -> PTraversal s a -> Maybe s -> r")
       * [`L.foldr((value, maybeValue, index) => value, value, traversal, maybeData) ~> value`](#L-foldr "L.foldr: ((r, Maybe a, Index) -> r) -> r -> PTraversal s a -> Maybe s -> r")
+      * [`L.isDefined(traversal, maybeData) ~> boolean`](#L-isDefined "L.isDefined: PTraversal s a -> Maybe s -> Boolean")
       * [`L.isEmpty(traversal, maybeData) ~> boolean`](#L-isEmpty "L.isEmpty: PTraversal s a -> Maybe s -> Boolean")
       * [`L.join(string, traversal, maybeData) ~> string`](#L-join "L.join: String -> PTraversal s a -> Maybe s -> String")
       * [`L.joinAs((maybeValue, index) => maybeString, string, traversal, maybeData) ~> string`](#L-joinAs "L.joinAs: ((Maybe a, Index) -> Maybe String) -> String -> PTraversal s a -> Maybe s -> String")
@@ -1593,6 +1594,18 @@ L.foldr((x, y) => x * y, 1, L.elems, [1,2,3])
 // 6
 ```
 
+##### <a id="L-isDefined"></a> [≡](#contents) [▶](https://calmm-js.github.io/partial.lenses/#L-isDefined) [`L.isDefined(traversal, maybeData) ~> boolean`](#L-isDefined "L.isDefined: PTraversal s a -> Maybe s -> Boolean")
+
+`L.isDefined` determines whether or not the given traversal focuses on any
+defined element on the given data structure.
+
+```js
+L.isDefined("x", {y: 1})
+// false
+```
+
+Note that `L.isDefined` is not the complement of [`L.isEmpty`](#L-isEmpty).
+
 ##### <a id="L-isEmpty"></a> [≡](#contents) [▶](https://calmm-js.github.io/partial.lenses/#L-isEmpty) [`L.isEmpty(traversal, maybeData) ~> boolean`](#L-isEmpty "L.isEmpty: PTraversal s a -> Maybe s -> Boolean")
 
 `L.isEmpty` determines whether or not the given traversal focuses on any
@@ -1602,6 +1615,8 @@ elements, `undefined` or otherwise, on the given data structure.
 L.isEmpty(flatten, [[],[[[],[]],[]]])
 // true
 ```
+
+Note that `L.isEmpty` is not the complement of [`L.isDefined`](#L-isDefined).
 
 ##### <a id="L-join"></a> [≡](#contents) [▶](https://calmm-js.github.io/partial.lenses/#L-join) [`L.join(string, traversal, maybeData) ~> string`](#L-join "L.join: String -> PTraversal s a -> Maybe s -> String")
 

--- a/README.md
+++ b/README.md
@@ -46,6 +46,8 @@ parts.  [Try Lenses!](https://calmm-js.github.io/partial.lenses/playground.html)
       * [`L.optional ~> optic`](#L-optional "L.optional: POptic a a")
       * [`L.when((maybeValue, index) => testable) ~> optic`](#L-when "L.when: ((Maybe a, Index) -> Boolean) -> POptic a a")
       * [`L.zero ~> optic`](#L-zero "L.zero: POptic s a")
+    * [Adapting](#adapting)
+      * [`L.orElse(backupOptic, primaryOptic) ~> optic`](#L-orElse "L.orElse: (POptic s a, POptic s a) -> POptic s a")
     * [Recursing](#recursing)
       * [`L.lazy(optic => optic) ~> optic`](#L-lazy "L.lazy: (POptic s a -> POptic s a) -> POptic s a")
     * [Transforming](#transforming)
@@ -113,7 +115,7 @@ parts.  [Try Lenses!](https://calmm-js.github.io/partial.lenses/playground.html)
       * [`L.filter((maybeValue, index) => testable) ~> lens`](#L-filter "L.filter: ((Maybe a, Index) -> Boolean) -> PLens [a] [a]")
       * [`L.find((maybeValue, index) => testable) ~> lens`](#L-find "L.find: ((Maybe a, Index) -> Boolean) -> PLens [a] a")
       * [`L.findHint((maybeValue, {hint: index}) => testable, {hint: index}) ~> lens`](#L-findHint "L.findHint: ((Maybe a, {hint: Index}) -> Boolean, {hint: Index}) -> PLens [a] a")
-      * [`L.findWith(...optics) ~> lens`](#L-findWith "L.findWith: (POptic s s1, ...POptic sN a) -> POptic [s] a")
+      * [`L.findWith(...optics) ~> optic`](#L-findWith "L.findWith: (POptic s s1, ...POptic sN a) -> POptic [s] a")
       * [`L.index(elemIndex) ~> lens`](#L-index "L.index: Integer -> PLens [a] a") or `elemIndex`
       * [`L.last ~> lens`](#L-last "L.last: PLens [a] a")
       * [`L.slice(maybeBegin, maybeEnd) ~> lens`](#L-slice "L.slice: Maybe Integer -> Maybe Integer -> PLens [a] [a]")
@@ -125,8 +127,6 @@ parts.  [Try Lenses!](https://calmm-js.github.io/partial.lenses/playground.html)
       * [`L.matches(/.../) ~> lens`](#L-matches "L.matches: RegExp -> PLens String String")
     * [Providing defaults](#providing-defaults)
       * [`L.valueOr(valueOut) ~> lens`](#L-valueOr "L.valueOr: s -> PLens s s")
-    * [Adapting to data](#adapting-to-data)
-      * [`L.orElse(backupOptic, primaryOptic) ~> lens`](#L-orElse "L.orElse: (POptic s a, POptic s a) -> POptic s a")
     * [Transforming data](#transforming-data)
       * [`L.pick({prop: lens, ...props}) ~> lens`](#L-pick "L.pick: {p1: PLens s a1, ...pls} -> PLens s {p1: a1, ...pls}")
       * [`L.replace(maybeValueIn, maybeValueOut) ~> lens`](#L-replace "L.replace: Maybe s -> Maybe s -> PLens s s")
@@ -1027,6 +1027,17 @@ L.collect([L.elems,
           [1, {x: 2}, [3,4]])
 // [ 2, 3, 4 ]
 ```
+
+#### Adapting
+
+##### <a id="L-orElse"></a> [≡](#contents) [▶](https://calmm-js.github.io/partial.lenses/#L-orElse) [`L.orElse(backupOptic, primaryOptic) ~> optic`](#L-orElse "L.orElse: (POptic s a, POptic s a) -> POptic s a")
+
+`L.orElse(backupOptic, primaryOptic)` acts like `primaryOptic` when its view is
+not `undefined` and otherwise like `backupOptic`.  You can use `L.orElse` on its
+own with [`R.reduceRight`](http://ramdajs.com/docs/#reduceRight)
+(and [`R.reduce`](http://ramdajs.com/docs/#reduce)) to create an associative
+choice over optics or use `L.orElse` to specify a default or backup optic
+for [`L.choice`](#L-choice), for example.
 
 #### Recursing
 
@@ -2147,7 +2158,7 @@ L.modify([L.findHint(R.whereEq({id: 2}), {hint: 2}), "value"],
 //  {id: 5, value: "e"}]
 ```
 
-##### <a id="L-findWith"></a> [≡](#contents) [▶](https://calmm-js.github.io/partial.lenses/#L-findWith) [`L.findWith(...optics) ~> lens`](#L-findWith "L.findWith: (POptic s s1, ...POptic sN a) -> POptic [s] a")
+##### <a id="L-findWith"></a> [≡](#contents) [▶](https://calmm-js.github.io/partial.lenses/#L-findWith) [`L.findWith(...optics) ~> optic`](#L-findWith "L.findWith: (POptic s s1, ...POptic sN a) -> POptic [s] a")
 
 `L.findWith(...optics)` chooses an index from an [array-like](#array-like)
 object through which the given optic, [`[...optics]`](#L-compose), has a
@@ -2459,17 +2470,6 @@ L.set(L.valueOr(0), 0, 1)
 L.remove(L.valueOr(0), 1)
 // undefined
 ```
-
-#### Adapting to data
-
-##### <a id="L-orElse"></a> [≡](#contents) [▶](https://calmm-js.github.io/partial.lenses/#L-orElse) [`L.orElse(backupOptic, primaryOptic) ~> lens`](#L-orElse "L.orElse: (POptic s a, POptic s a) -> POptic s a")
-
-`L.orElse(backupOptic, primaryOptic)` acts like `primaryOptic` when its view is
-not `undefined` and otherwise like `backupOptic`.  You can use `L.orElse` on its
-own with [`R.reduceRight`](http://ramdajs.com/docs/#reduceRight)
-(and [`R.reduce`](http://ramdajs.com/docs/#reduce)) to create an associative
-choice over optics or use `L.orElse` to specify a default or backup optic
-for [`L.choice`](#L-choice), for example.
 
 #### Transforming data
 

--- a/src/partial.lenses.js
+++ b/src/partial.lenses.js
@@ -705,7 +705,7 @@ export const chain = /*#__PURE__*/I.curry((xi2yO, xO) =>
   [xO, choose((xM, i) => void 0 !== xM ? xi2yO(xM, i) : zero)])
 
 export const choice = (...os) => choose(x => {
-  const o = os[findIndex(o => void 0 !== select(o, x), os)]
+  const o = os[findIndex(o => isDefined(o, x), os)]
   return void 0 !== o ? o : zero
 })
 
@@ -722,7 +722,7 @@ export const zero = (x, i, C, xi2yC) => zeroOp(x, i, C, xi2yC)
 // Adapting
 
 export const orElse = /*#__PURE__*/I.curry((back, prim) =>
-  choose(x => void 0 !== select(prim, x) ? prim : back))
+  choose(x => isDefined(prim, x) ? prim : back))
 
 // Recursing
 
@@ -871,6 +871,8 @@ export const foldr = /*#__PURE__*/I.curry((f, r, t, s) => {
   }
   return r
 })
+
+export const isDefined = /*#__PURE__*/I.pipe2U(mkSelect(x => void 0 !== x ? T : U), Boolean)()
 
 export const isEmpty = /*#__PURE__*/I.pipe2U(mkSelect(I.always(T)), not)()
 
@@ -1031,7 +1033,7 @@ export const findHint = /*#__PURE__*/I.curry((xh2b, hint) => {
 
 export function findWith(...os) {
   const oos = compose(...os)
-  return [find(x => void 0 !== select(oos, x)), oos]
+  return [find(x => isDefined(oos, x)), oos]
 }
 
 export const index = process.env.NODE_ENV === "production" ? I.id : checkIndex

--- a/src/partial.lenses.js
+++ b/src/partial.lenses.js
@@ -704,9 +704,9 @@ export function compose() {
 export const chain = /*#__PURE__*/I.curry((xi2yO, xO) =>
   [xO, choose((xM, i) => void 0 !== xM ? xi2yO(xM, i) : zero)])
 
-export const choice = (...ls) => choose(x => {
-  const l = ls[findIndex(l => void 0 !== getU(l, x), ls)]
-  return void 0 !== l ? l : zero
+export const choice = (...os) => choose(x => {
+  const o = os[findIndex(o => void 0 !== select(o, x), os)]
+  return void 0 !== o ? o : zero
 })
 
 export const choose = xiM2o => (x, i, C, xi2yC) =>
@@ -1024,9 +1024,9 @@ export const findHint = /*#__PURE__*/I.curry((xh2b, hint) => {
   }
 })
 
-export function findWith(...ls) {
-  const lls = compose(...ls)
-  return [find(x => void 0 !== getU(lls, x)), lls]
+export function findWith(...os) {
+  const oos = compose(...os)
+  return [find(x => void 0 !== select(oos, x)), oos]
 }
 
 export const index = process.env.NODE_ENV === "production" ? I.id : checkIndex
@@ -1090,8 +1090,8 @@ export const valueOr = v => (x, i, _F, xi2yF) => xi2yF(x != null ? x : v, i)
 
 // Adapting to data
 
-export const orElse = /*#__PURE__*/I.curry((d, l) =>
-  choose(x => void 0 !== getU(l, x) ? l : d))
+export const orElse = /*#__PURE__*/I.curry((back, prim) =>
+  choose(x => void 0 !== select(prim, x) ? prim : back))
 
 // Transforming data
 

--- a/src/partial.lenses.js
+++ b/src/partial.lenses.js
@@ -719,6 +719,11 @@ export const optional = /*#__PURE__*/when(I.isDefined)
 
 export const zero = (x, i, C, xi2yC) => zeroOp(x, i, C, xi2yC)
 
+// Adapting
+
+export const orElse = /*#__PURE__*/I.curry((back, prim) =>
+  choose(x => void 0 !== select(prim, x) ? prim : back))
+
 // Recursing
 
 export function lazy(o2o) {
@@ -1087,11 +1092,6 @@ export function removable(...ps) {
 // Providing defaults
 
 export const valueOr = v => (x, i, _F, xi2yF) => xi2yF(x != null ? x : v, i)
-
-// Adapting to data
-
-export const orElse = /*#__PURE__*/I.curry((back, prim) =>
-  choose(x => void 0 !== select(prim, x) ? prim : back))
 
 // Transforming data
 

--- a/test/tests.js
+++ b/test/tests.js
@@ -203,6 +203,7 @@ describe("arities", () => {
     index: 1,
     inverse: 1,
     is: 1,
+    isDefined: 2,
     isEmpty: 2,
     iso: 2,
     join: 3,
@@ -652,6 +653,11 @@ describe("L.traverse", () => {
 })
 
 describe("folds", () => {
+  testEq(`L.isDefined(L.elems, [])`, false)
+  testEq(`L.isDefined(L.elems, [1])`, true)
+  testEq(`L.isDefined("x", {y: 1})`, false)
+  testEq(`L.isDefined([L.elems, "x"], [{}])`, false)
+  testEq(`L.isDefined([L.elems, "x", L.optional], [{}])`, false)
   testEq(`L.isEmpty(L.elems, [])`, true)
   testEq(`L.isEmpty(L.elems, [1])`, false)
   testEq(`L.isEmpty([L.elems, "x"], [{}])`, false)

--- a/test/tests.js
+++ b/test/tests.js
@@ -451,6 +451,9 @@ describe("L.orElse", () => {
   testEq(`L.get(L.orElse("b", "a"), {b: 2})`, 2)
   testEq(`L.set(L.orElse("b", "a"), 3, {a: 2, b: 1})`, {a: 3, b: 1})
   testEq(`L.set(L.orElse("b", "a"), 3, {b: 2})`, {b: 3})
+  testEq(`L.modify(L.orElse(L.values, L.elems), R.inc, {x: 1, y: 2})`,
+         {x: 2, y: 3})
+  testEq(`L.modify(L.orElse(L.values, L.elems), R.inc, [2,0,3])`, [3,1,4])
 })
 
 describe("L.choice", () => {
@@ -460,6 +463,9 @@ describe("L.choice", () => {
   testEq(`L.set(L.choice("x", "y"), "A", {x: "a"})`, {x: "A"})
   testEq(`L.set(L.choice("x", "y"), "B", {y: "b"})`, {y: "B"})
   testEq(`L.set(L.choice("x", "y"), "C", {z: "c"})`, {z: "c"})
+  testEq(`L.modify(L.choice(L.elems, L.values), R.inc, {x: 1, y: 2})`,
+         {x: 2, y: 3})
+  testEq(`L.modify(L.choice(L.elems, L.values), R.inc, [2,0,3])`, [3,1,4])
 })
 
 describe("L.findWith", () => {
@@ -468,6 +474,7 @@ describe("L.findWith", () => {
          [{x: ["a"]},{x: ["b","d"]}])
   testEq(`L.remove(L.findWith("x", 1), [{x: ["a"]},{x: ["b","c"]}])`,
          [{x: ["a"]},{x: ["b"]}])
+  testEq(`L.collect(L.findWith(L.elems), [1,[2],3])`, [2])
 })
 
 describe("L.filter", () => {

--- a/test/types.js
+++ b/test/types.js
@@ -165,6 +165,7 @@ export const foldl =
        T.any)
 export const foldr = foldl
 
+export const isDefined = T.fn([T_traversal, T_maybeDataI], T.boolean)
 export const isEmpty = T.fn([T_traversal, T_maybeDataI], T.boolean)
 
 export const joinAs =

--- a/test/types.js
+++ b/test/types.js
@@ -88,11 +88,15 @@ export const compose = T.fnVar(T_optic, T_optic)
 // Querying
 
 export const chain = T.fn([T.fn([T_dataO, T_index], T_optic), T_lens], T_optic)
-export const choice = T.fnVar(T_lens, T_optic)
+export const choice = T.fnVar(T_optic, T_optic)
 export const choose = T.fn([T.fn([T_maybeDataO, T_index], T_optic)], T_optic)
 export const optional = T_optic
 export const when = T.fn([T.fn([T_maybeDataO, T_index], T.any)], T_optic)
 export const zero = T_optic
+
+// Adapting
+
+export const orElse = T.fn([T_optic, T_optic], T_optic)
 
 // Recursing
 
@@ -241,7 +245,7 @@ export const append = T_lens
 export const filter = T.fn([T.fn([T_maybeDataO, T_index], T.any)], T_lens)
 export const find = T.fn([T.fn([T_maybeDataO, T_index], T.any)], T_lens)
 export const findHint = T.fn([T.fn([T_maybeDataO, hint], T.any), hint], T_lens)
-export const findWith = T.fnVar(T_lens, T_lens)
+export const findWith = T.fnVar(T_optic, T_optic)
 export const index = T.fn([T.nonNegative], T_lens)
 export const last = T_lens
 export const slice = T.fn([T_sliceIndex, T_sliceIndex], T_lens)
@@ -255,10 +259,6 @@ export const removable = T.fnVar(T.string, T_lens)
 // Providing defaults
 
 export const valueOr = T.fn([T.any], T_lens)
-
-// Adapting to data
-
-export const orElse = T.fn([T_lens, T_lens], T_lens)
 
 // Transforming data
 


### PR DESCRIPTION
Previously they accepted only lenses, but now that we have `select`, they can be
generalized to work with traversals as well.