### PR TITLE
Adding `indexed`, `keyed`, `entries`, and `keys`

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,9 @@ parts.  [Try Lenses!](https://calmm-js.github.io/partial.lenses/playground.html)
       * [`L.branch({prop: traversal, ...props}) ~> traversal`](#L-branch "L.branch: {p1: PTraversal s a, ...pts} -> PTraversal s a") <small><sup>v5.1.0</sup></small>
     * [Traversals and combinators](#traversals-and-combinators)
       * [`L.elems ~> traversal`](#L-elems "L.elems: PTraversal [a] a") <small><sup>v7.3.0</sup></small>
+      * [`L.entries ~> traversal`](#L-entries "L.entries: PTraversal {p: a, ...ps} [String, a]") <small><sup>v11.21.0</sup></small>
       * [`L.flatten ~> traversal`](#L-flatten "L.flatten: PTraversal [...[a]...] a") <small><sup>v11.16.0</sup></small>
+      * [`L.keys ~> traversal`](#L-keys "L.keys: PTraversal {p: a, ...ps} String") <small><sup>v11.21.0</sup></small>
       * [`L.matches(/.../g) ~> traversal`](#L-matches-g "L.matches: RegExp -> PTraversal String String") <small><sup>v10.4.0</sup></small>
       * [`L.values ~> traversal`](#L-values "L.values: PTraversal {p: a, ...ps} a") <small><sup>v7.3.0</sup></small>
     * [Folds over traversals](#folds-over-traversals)
@@ -160,7 +162,9 @@ parts.  [Try Lenses!](https://calmm-js.github.io/partial.lenses/playground.html)
     * [Basic isomorphisms](#basic-isomorphisms)
       * [`L.complement ~> isomorphism`](#L-complement "L.complement: PIso Boolean Boolean") <small><sup>v9.7.0</sup></small>
       * [`L.identity ~> isomorphism`](#L-identity "L.identity: PIso s s") <small><sup>v1.3.0</sup></small>
+      * [`L.indexed ~> isomorphism`](#L-indexed "L.indexed: PIso [a] [[Integer, a]]") <small><sup>v11.21.0</sup></small>
       * [`L.is(value) ~> isomorphism`](#L-is "L.is: v -> PIso v Boolean") <small><sup>v11.1.0</sup></small>
+      * [`L.keyed ~> isomorphism`](#L-keyed "L.keyed: PIso {p: a, ...ps} [[String, a]]") <small><sup>v11.21.0</sup></small>
       * [`L.singleton ~> isomorphism`](#L-singleton "L.singleton: PIso [a] a") <small><sup>v11.18.0</sup></small>
     * [Standard isomorphisms](#standard-isomorphisms)
       * [`L.uri ~> isomorphism`](#L-uri "L.uri: PIso String String") <small><sup>v11.3.0</sup></small>
@@ -1620,6 +1624,18 @@ L.modify([L.rewrite(xs => Int8Array.from(xs)), L.elems],
 // Int8Array [ 0, 5, 1, 3, 5 ]
 ```
 
+##### <a id="L-entries"></a> [≡](#contents) [▶](https://calmm-js.github.io/partial.lenses/#L-entries) [`L.entries ~> traversal`](#L-entries "L.entries: PTraversal {p: a, ...ps} [String, a]") <small><sup>v11.21.0</sup></small>
+
+`L.entries` is a traversal over the entries, or `[key, value]` pairs, of an
+object.
+
+For example:
+
+```js
+L.modify(L.entries, ([k, v]) => [v, k], {x: "a", y: "b"})
+// { a: 'x', b: 'y' }
+```
+
 ##### <a id="L-flatten"></a> [≡](#contents) [▶](https://calmm-js.github.io/partial.lenses/#L-flatten) [`L.flatten ~> traversal`](#L-flatten "L.flatten: PTraversal [...[a]...] a") <small><sup>v11.16.0</sup></small>
 
 `L.flatten` is a traversal over the elements of arbitrarily nested arrays.
@@ -1631,6 +1647,17 @@ For example:
 ```js
 L.join(" ", L.flatten, [[[1]], ["2"], 3])
 // "1 2 3"
+```
+
+##### <a id="L-keys"></a> [≡](#contents) [▶](https://calmm-js.github.io/partial.lenses/#L-keys) [`L.keys ~> traversal`](#L-keys "L.keys: PTraversal {p: a, ...ps} String") <small><sup>v11.21.0</sup></small>
+
+`L.keys` is a traversal over the keys of an object.
+
+For example:
+
+```js
+L.modify(L.keys, R.toUpper, {x: 1, y: 2})
+// { X: 1, Y: 2 }
 ```
 
 ##### <a id="L-matches-g"></a> [≡](#contents) [▶](https://calmm-js.github.io/partial.lenses/#L-matches-g) [`L.matches(/.../g) ~> traversal`](#L-matches-g "L.matches: RegExp -> PTraversal String String") <small><sup>v10.4.0</sup></small>
@@ -3121,6 +3148,24 @@ L.modify(L.identity, f, x) = f(x)
   L.compose(l, L.identity) = l
 ```
 
+##### <a id="L-indexed"></a> [≡](#contents) [▶](https://calmm-js.github.io/partial.lenses/#L-indexed) [`L.indexed ~> isomorphism`](#L-indexed "L.indexed: PIso [a] [[Integer, a]]") <small><sup>v11.21.0</sup></small>
+
+`L.indexed` is an isomorphism between an [array-like](#array-like) object and an
+array of `[index, value]` pairs.
+
+For example:
+
+```js
+L.modify([L.rewrite(R.join('')),
+          L.indexed,
+          L.normalize(R.sortBy(L.get(1))),
+          0,
+          1],
+         R.toUpper,
+         "optics")
+// 'optiCs'
+```
+
 ##### <a id="L-complement"></a> [≡](#contents) [▶](https://calmm-js.github.io/partial.lenses/#L-complement) [`L.complement ~> isomorphism`](#L-complement "L.complement: PIso Boolean Boolean") <small><sup>v9.7.0</sup></small>
 
 `L.complement` is an isomorphism that performs logical negation of any
@@ -3142,6 +3187,18 @@ L.set([L.complement, L.log()],
 `L.is` reads the given value as `true` and everything else as `false` and writes
 `true` as the given value and everything else as `undefined`.
 See [here](#an-array-of-ids-as-boolean-flags) for an example.
+
+##### <a id="L-keyed"></a> [≡](#contents) [▶](https://calmm-js.github.io/partial.lenses/#L-keyed) [`L.keyed ~> isomorphism`](#L-keyed "L.keyed: PIso {p: a, ...ps} [[String, a]]") <small><sup>v11.21.0</sup></small>
+
+`L.keyed` is an isomorphism between an object and an array of `[key, value]`
+pairs.
+
+For example:
+
+```js
+L.get(L.keyed, {a: 1, b: 2})
+// [ ['a', 1], ['b', 2] ]
+```
 
 ##### <a id="L-singleton"></a> [≡](#contents) [▶](https://calmm-js.github.io/partial.lenses/#L-singleton) [`L.singleton ~> isomorphism`](#L-singleton "L.singleton: PIso [a] a") <small><sup>v11.18.0</sup></small>
 

--- a/src/partial.lenses.js
+++ b/src/partial.lenses.js
@@ -25,6 +25,8 @@ const notPartial = x => void 0 !== x ? !x : x
 
 const singletonPartial = x => void 0 !== x ? [x] : void 0
 
+const instanceofObject = x => x instanceof Object
+
 const expect = (p, f) => x => p(x) ? f(x) : void 0
 
 const freeze = x => x && Object.freeze(x)
@@ -40,6 +42,13 @@ function deepFreeze(x) {
   }
   return x
 }
+
+function freezeArrayOfObjects(xs) {
+  xs.forEach(freeze)
+  return freeze(xs)
+}
+
+const indexCmp = ({index: l}, {index: r}) => l - r
 
 //
 
@@ -660,6 +669,27 @@ function iterEager(map, ap, of, _, xi2yA, t, s) {
 
 //
 
+const keyed = /*#__PURE__*/isoU(expect(instanceofObject, (process.env.NODE_ENV === "production" ? I.id : C.res(freezeArrayOfObjects))(x => {
+  x = toObject(x)
+  const es = []
+  for (const key in x)
+    es.push({key, value: x[key]})
+  return es
+})), expect(I.isDefined, (process.env.NODE_ENV === "production" ? I.id : C.res(freeze))(es => {
+  let o = void 0
+  for (let i=0, n=es.length; i<n; ++i) {
+    const {key, value} = es[i]
+    if (void 0 !== key && void 0 !== value) {
+      if (void 0 === o)
+        o = {}
+      o[key] = value
+    }
+  }
+  return o
+})))
+
+//
+
 const matchesJoin = input => matches => {
   let result = ""
   let lastIndex = 0
@@ -692,6 +722,12 @@ function zeroOp(y, i, C, xi2yC, x) {
 //
 
 const pickInAux = (t, k) => [k, pickIn(t)]
+
+// Auxiliary
+
+export const seemsArrayLike = x =>
+  x instanceof Object && (x = x.length, x === (x >> 0) && 0 <= x) ||
+  I.isString(x)
 
 // Internals
 
@@ -853,6 +889,8 @@ export const elems = /*#__PURE__*/(process.env.NODE_ENV === "production" ? I.id 
     return A.of(xs)
   }
 })
+
+export const entries = /*#__PURE__*/toFunction([keyed, elems])
 
 export const flatten =
   /*#__PURE__*/lazy(rec => iftes(Array.isArray, [elems, rec], identity))
@@ -1183,9 +1221,33 @@ export const complement = /*#__PURE__*/isoU(notPartial, notPartial)
 
 export const identity = (x, i, _F, xi2yF) => xi2yF(x, i)
 
+export const indexed = /*#__PURE__*/isoU(expect(seemsArrayLike, (process.env.NODE_ENV === "production" ? I.id : C.res(freezeArrayOfObjects))(xs => {
+  const n = xs.length, xis = Array(n)
+  for (let i=0; i<n; ++i)
+    xis[i] = {value: xs[i], index: i}
+  return xis
+})), expect(I.isDefined, (process.env.NODE_ENV === "production" ? I.id : C.res(freeze))(xisIn => {
+  const n = xisIn.length, xis = Array(n)
+  let m = 0
+  for (let i=0; i<n; ++i) {
+    const xi = xisIn[i]
+    if (void 0 !== xi && void 0 !== xi.value && void 0 !== xi.index)
+      xis[m++] = xi
+  }
+  if (m) {
+    xis.length = m
+    xis.sort(indexCmp)
+    for (let i=0; i<m; ++i)
+      xis[i] = xis[i].value
+    return xis
+  }
+})))
+
 export const is = v =>
   isoU(x => I.acyclicEqualsU(v, x),
        b => true === b ? v : void 0)
+
+export {keyed}
 
 export const singleton = /*#__PURE__*/(process.env.NODE_ENV === "production" ? I.id : iso => toFunction([isoU(I.id, freeze), iso]))(
   (x, i, F, xi2yF) =>
@@ -1210,9 +1272,3 @@ export const json = /*#__PURE__*/(process.env.NODE_ENV === "production" ? I.id :
   return isoU(expect(I.isString, text => JSON.parse(text, reviver)),
               expect(I.isDefined, value => JSON.stringify(value, replacer, space)))
 })
-
-// Auxiliary
-
-export const seemsArrayLike = x =>
-  x instanceof Object && (x = x.length, x === (x >> 0) && 0 <= x) ||
-  I.isString(x)

--- a/src/partial.lenses.js
+++ b/src/partial.lenses.js
@@ -48,7 +48,7 @@ function freezeArrayOfObjects(xs) {
   return freeze(xs)
 }
 
-const indexCmp = ({index: l}, {index: r}) => l - r
+const indexCmp = (l, r) => l[0] - r[0]
 
 //
 
@@ -673,16 +673,19 @@ const keyed = /*#__PURE__*/isoU(expect(instanceofObject, (process.env.NODE_ENV =
   x = toObject(x)
   const es = []
   for (const key in x)
-    es.push({key, value: x[key]})
+    es.push([key, x[key]])
   return es
 })), expect(I.isDefined, (process.env.NODE_ENV === "production" ? I.id : C.res(freeze))(es => {
   let o = void 0
   for (let i=0, n=es.length; i<n; ++i) {
-    const {key, value} = es[i]
-    if (void 0 !== key && void 0 !== value) {
-      if (void 0 === o)
-        o = {}
-      o[key] = value
+    const entry = es[i]
+    if (entry.length === 2) {
+      const key = entry[0], value = entry[1]
+      if (void 0 !== key && void 0 !== value) {
+        if (void 0 === o)
+          o = {}
+        o[key] = value
+      }
     }
   }
   return o
@@ -894,6 +897,8 @@ export const entries = /*#__PURE__*/toFunction([keyed, elems])
 
 export const flatten =
   /*#__PURE__*/lazy(rec => iftes(Array.isArray, [elems, rec], identity))
+
+export const keys = /*#__PURE__*/toFunction([keyed, elems, 0])
 
 export const matches = /*#__PURE__*/(process.env.NODE_ENV === "production" ? I.id : C.dep(([re]) => re.global ? C.res(C.par(2, C.ef(reqApplicative("matches", re)))) : I.id))(re => {
   return (x, _i, C, xi2yC) => {
@@ -1224,21 +1229,21 @@ export const identity = (x, i, _F, xi2yF) => xi2yF(x, i)
 export const indexed = /*#__PURE__*/isoU(expect(seemsArrayLike, (process.env.NODE_ENV === "production" ? I.id : C.res(freezeArrayOfObjects))(xs => {
   const n = xs.length, xis = Array(n)
   for (let i=0; i<n; ++i)
-    xis[i] = {value: xs[i], index: i}
+    xis[i] = [i, xs[i]]
   return xis
 })), expect(I.isDefined, (process.env.NODE_ENV === "production" ? I.id : C.res(freeze))(xisIn => {
   const n = xisIn.length, xis = Array(n)
   let m = 0
   for (let i=0; i<n; ++i) {
     const xi = xisIn[i]
-    if (void 0 !== xi && void 0 !== xi.value && void 0 !== xi.index)
+    if (xi.length === 2 && void 0 !== xi[0] && void 0 !== xi[1])
       xis[m++] = xi
   }
   if (m) {
     xis.length = m
     xis.sort(indexCmp)
     for (let i=0; i<m; ++i)
-      xis[i] = xis[i].value
+      xis[i] = xis[i][1]
     return xis
   }
 })))

--- a/src/partial.lenses.js
+++ b/src/partial.lenses.js
@@ -48,8 +48,6 @@ function freezeArrayOfObjects(xs) {
   return freeze(xs)
 }
 
-const indexCmp = (l, r) => l[0] - r[0]
-
 //
 
 const mapPartialIndexU = /*#__PURE__*/(process.env.NODE_ENV === "production" ? I.id : C.res(freeze))((xi2y, xs) => {
@@ -680,12 +678,9 @@ const keyed = /*#__PURE__*/isoU(expect(instanceofObject, (process.env.NODE_ENV =
   for (let i=0, n=es.length; i<n; ++i) {
     const entry = es[i]
     if (entry.length === 2) {
-      const key = entry[0], value = entry[1]
-      if (void 0 !== key && void 0 !== value) {
-        if (void 0 === o)
-          o = {}
-        o[key] = value
-      }
+      if (void 0 === o)
+        o = {}
+      o[entry[0]] = entry[1]
     }
   }
   return o
@@ -1231,20 +1226,26 @@ export const indexed = /*#__PURE__*/isoU(expect(seemsArrayLike, (process.env.NOD
   for (let i=0; i<n; ++i)
     xis[i] = [i, xs[i]]
   return xis
-})), expect(I.isDefined, (process.env.NODE_ENV === "production" ? I.id : C.res(freeze))(xisIn => {
-  const n = xisIn.length, xis = Array(n)
-  let m = 0
+})), expect(I.isDefined, (process.env.NODE_ENV === "production" ? I.id : C.res(freeze))(xis => {
+  let n = xis.length, xs = Array(n)
   for (let i=0; i<n; ++i) {
-    const xi = xisIn[i]
-    if (xi.length === 2 && void 0 !== xi[0] && void 0 !== xi[1])
-      xis[m++] = xi
+    const xi = xis[i]
+    if (xi.length === 2)
+      xs[xi[0]] = xi[1]
   }
-  if (m) {
-    xis.length = m
-    xis.sort(indexCmp)
-    for (let i=0; i<m; ++i)
-      xis[i] = xis[i][1]
-    return xis
+  n = xs.length
+  let j=0
+  for (let i=0; i<n; ++i) {
+    const x = xs[i]
+    if (void 0 !== x) {
+      if (i !== j)
+        xs[j] = x
+      ++j
+    }
+  }
+  if (j) {
+    xs.length = j
+    return xs
   }
 })))
 

--- a/test/tests.js
+++ b/test/tests.js
@@ -1248,7 +1248,7 @@ describe("L.keyed", () => {
 })
 
 describe("L.entries", () => {
-  testEq(`L.modify(L.entries, ([k, v]) => [v, k], {x: "a", y: "b"})`, {a: "x", b: "y"})
+  testEq(`L.modify(L.entries, (kv) => [kv[1], kv[0]], {x: "a", y: "b"})`, {a: "x", b: "y"})
   testEq(`L.remove([L.entries, 1, L.when(x => x === "a")], {x: "a", y: "b"})`, {y: "b"})
 })
 

--- a/test/tests.js
+++ b/test/tests.js
@@ -1232,7 +1232,7 @@ describe("L.indexed", () => {
   testEq(`L.get(L.indexed, ["a", "b"])`, [[0, "a"], [1, "b"]])
   testEq(`L.getInverse(L.indexed, [[0, "a"], [1, "b"]])`, ["a", "b"])
   testEq(`L.set(L.indexed, [], ["a", "b"])`, undefined)
-  testEq(`L.set([L.indexed, 2], [-1, "c"], ["a", "b"])`, ["c", "a", "b"])
+  testEq(`L.set([L.indexed, 2], [0, "c"], ["a", "b"])`, ["c", "b"])
   testEq(`L.set([L.indexed, 2], [3, "c"], ["a", "b"])`, ["a", "b", "c"])
   testEq(`L.remove([L.indexed, 1, 0], ["a", "b"])`, ["a"])
   testEq(`L.remove([L.indexed, 0, 1], ["a", "b"])`, ["b"])

--- a/test/tests.js
+++ b/test/tests.js
@@ -218,6 +218,7 @@ describe("arities", () => {
     defaults: 1,
     define: 1,
     elems: 4,
+    entries: 4,
     filter: 1,
     find: 1,
     findHint: 2,
@@ -232,6 +233,7 @@ describe("arities", () => {
     identity: 4,
     iftes: 2,
     index: 1,
+    indexed: 4,
     inverse: 1,
     is: 1,
     isDefined: 2,
@@ -240,6 +242,7 @@ describe("arities", () => {
     join: 3,
     joinAs: 4,
     json: 1,
+    keyed: 4,
     last: 4,
     lazy: 1,
     lens: 2,
@@ -1222,6 +1225,24 @@ describe("LazyIdent", () => {
                    R.toUpper,
                    "Hello, world!")`,
          "HELLO, wOrLd!")
+})
+
+describe("L.indexed", () => {
+  testEq(`L.get(L.indexed, ["a", "b"])`,
+         [{value: "a", index: 0}, {value: "b", index: 1}])
+  testEq(`L.getInverse(L.indexed, [{value: "a", index: 0}, {value: "b", index: 1}])`,
+         ["a", "b"])
+})
+
+describe("L.keyed", () => {
+  testEq(`L.get(L.keyed, {x: 4, y: 2})`,
+         [{value: 4, key: "x"}, {value: 2, key: "y"}])
+  testEq(`L.getInverse(L.keyed, [{value: 4, key: "x"}, {value: 2, key: "y"}])`,
+         {x: 4, y: 2})
+})
+
+describe("L.entries", () => {
+  testEq(`L.modify([L.entries, "key"], R.toUpper, {x: 6, y: 9})`, {X: 6, Y: 9})
 })
 
 if (process.env.NODE_ENV !== "production") {

--- a/test/tests.js
+++ b/test/tests.js
@@ -1231,18 +1231,30 @@ describe("LazyIdent", () => {
 describe("L.indexed", () => {
   testEq(`L.get(L.indexed, ["a", "b"])`, [[0, "a"], [1, "b"]])
   testEq(`L.getInverse(L.indexed, [[0, "a"], [1, "b"]])`, ["a", "b"])
+  testEq(`L.set(L.indexed, [], ["a", "b"])`, undefined)
+  testEq(`L.set([L.indexed, 2], [-1, "c"], ["a", "b"])`, ["c", "a", "b"])
+  testEq(`L.set([L.indexed, 2], [3, "c"], ["a", "b"])`, ["a", "b", "c"])
+  testEq(`L.remove([L.indexed, 1, 0], ["a", "b"])`, ["a"])
+  testEq(`L.remove([L.indexed, 0, 1], ["a", "b"])`, ["b"])
 })
 
 describe("L.keyed", () => {
   testEq(`L.get(L.keyed, {x: 4, y: 2})`, [["x", 4], ["y", 2]])
   testEq(`L.getInverse(L.keyed, [["x", 4], ["y", 2]])`, {x: 4, y: 2})
+  testEq(`L.set(L.keyed, {}, {x: 4, y: 2})`, undefined)
+  testEq(`L.set([L.keyed, 2], ["z", 6], {x: 4, y: 2})`, {x: 4, y: 2, z: 6})
+  testEq(`L.remove([L.keyed, 1, 0], {x: 4, y: 2})`, {x: 4})
+  testEq(`L.remove([L.keyed, 0, 1], {x: 4, y: 2})`, {y: 2})
 })
 
 describe("L.entries", () => {
+  testEq(`L.modify(L.entries, ([k, v]) => [v, k], {x: "a", y: "b"})`, {a: "x", b: "y"})
+  testEq(`L.remove([L.entries, 1, L.when(x => x === "a")], {x: "a", y: "b"})`, {y: "b"})
 })
 
 describe("L.keys", () => {
   testEq(`L.modify(L.keys, R.toUpper, {x: 6, y: 9})`, {X: 6, Y: 9})
+  testEq(`L.remove([L.keys, L.when(x => x > "b")], {a: 1, c: 3, b: 2})`, {a: 1, b: 2})
 })
 
 if (process.env.NODE_ENV !== "production") {

--- a/test/tests.js
+++ b/test/tests.js
@@ -243,6 +243,7 @@ describe("arities", () => {
     joinAs: 4,
     json: 1,
     keyed: 4,
+    keys: 4,
     last: 4,
     lazy: 1,
     lens: 2,
@@ -1228,21 +1229,20 @@ describe("LazyIdent", () => {
 })
 
 describe("L.indexed", () => {
-  testEq(`L.get(L.indexed, ["a", "b"])`,
-         [{value: "a", index: 0}, {value: "b", index: 1}])
-  testEq(`L.getInverse(L.indexed, [{value: "a", index: 0}, {value: "b", index: 1}])`,
-         ["a", "b"])
+  testEq(`L.get(L.indexed, ["a", "b"])`, [[0, "a"], [1, "b"]])
+  testEq(`L.getInverse(L.indexed, [[0, "a"], [1, "b"]])`, ["a", "b"])
 })
 
 describe("L.keyed", () => {
-  testEq(`L.get(L.keyed, {x: 4, y: 2})`,
-         [{value: 4, key: "x"}, {value: 2, key: "y"}])
-  testEq(`L.getInverse(L.keyed, [{value: 4, key: "x"}, {value: 2, key: "y"}])`,
-         {x: 4, y: 2})
+  testEq(`L.get(L.keyed, {x: 4, y: 2})`, [["x", 4], ["y", 2]])
+  testEq(`L.getInverse(L.keyed, [["x", 4], ["y", 2]])`, {x: 4, y: 2})
 })
 
 describe("L.entries", () => {
-  testEq(`L.modify([L.entries, "key"], R.toUpper, {x: 6, y: 9})`, {X: 6, Y: 9})
+})
+
+describe("L.keys", () => {
+  testEq(`L.modify(L.keys, R.toUpper, {x: 6, y: 9})`, {X: 6, Y: 9})
 })
 
 if (process.env.NODE_ENV !== "production") {

--- a/test/types.js
+++ b/test/types.js
@@ -135,6 +135,7 @@ export const branch = T.fn([template(T_traversal)], T_traversal)
 // Traversals and combinators
 
 export const elems = T_traversal
+export const entries = T_traversal
 export const flatten = T_traversal
 export const matches = T.fn([T.instanceOf(RegExp)], T_optic)
 export const values = T_traversal
@@ -314,7 +315,9 @@ export const inverse = T.fn([T_isomorphism], T_isomorphism)
 
 export const complement = T_isomorphism
 export const identity = T_isomorphism
+export const indexed = T_isomorphism
 export const is = T.fn([T.def], T_lens)
+export const keyed = T_isomorphism
 export const singleton = T_isomorphism
 
 // Standard isomorphisms

--- a/test/types.js
+++ b/test/types.js
@@ -137,6 +137,7 @@ export const branch = T.fn([template(T_traversal)], T_traversal)
 export const elems = T_traversal
 export const entries = T_traversal
 export const flatten = T_traversal
+export const keys = T_traversal
 export const matches = T.fn([T.instanceOf(RegExp)], T_optic)
 export const values = T_traversal
 


### PR DESCRIPTION
Not yet ready.

* [x] consider using the `[key/index, value]` format of [JS built-in entries](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map/entries)
* [x] `keys: PTraversal {k1: v1, ...} String`
* [x] consider radix sort (or just writing by index) for `indexed`
* [x] test
* [x] document

Closes #119 
Closes #110 