### PR TITLE
Added `branchOr`

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ parts.  [Try Lenses!](https://calmm-js.github.io/partial.lenses/playground.html)
   * [Traversals](#traversals)
     * [Creating new traversals](#creating-new-traversals)
       * [`L.branch({prop: traversal, ...props}) ~> traversal`](#L-branch "L.branch: {p1: PTraversal s a, ...pts} -> PTraversal s a") <small><sup>v5.1.0</sup></small>
+      * [`L.branchOr(traversal, {prop: traversal, ...props}) ~> traversal`](#L-branchOr "L.branchOr: PTraversal s a -> {p1: PTraversal s a, ...pts} -> PTraversal s a") <small><sup>v13.2.0</sup></small>
     * [Traversals and combinators](#traversals-and-combinators)
       * [`L.elems ~> traversal`](#L-elems "L.elems: PTraversal [a] a") <small><sup>v7.3.0</sup></small>
       * [`L.entries ~> traversal`](#L-entries "L.entries: PTraversal {p: a, ...ps} [String, a]") <small><sup>v11.21.0</sup></small>
@@ -1740,6 +1741,8 @@ property is mapped to [`L.identity`](#L-identity) in the template given to
 `L.branch`, it means that the element is to be visited by the resulting
 traversal.
 
+Note that `L.branch` is equivalent to [`L.branchOr(L.zero)`](#L-branchOr).
+
 Note that you can also compose `L.branch` with other optics.  For example, you
 can compose with [`L.pick`](#L-pick) to create a traversal over specific
 elements of an array:
@@ -1753,6 +1756,23 @@ L.modify([L.pick({z: 2, x: 0}),
 ```
 
 See the [BST traversal](#bst-traversal) section for a more meaningful example.
+
+##### <a id="L-branchOr"></a> [≡](#contents) [▶](https://calmm-js.github.io/partial.lenses/index.html#L-branchOr) [`L.branchOr(traversal, {prop: traversal, ...props}) ~> traversal`](#L-branchOr "L.branchOr: PTraversal s a -> {p1: PTraversal s a, ...pts} -> PTraversal s a") <small><sup>v13.2.0</sup></small>
+
+`L.branchOr` creates a new traversal from a given traversal and a given possibly
+nested template object.  The template specifies how the new traversal should
+visit the corresponding properties of an object.  The separate traversal is used
+for properties not defined in the template.
+
+For example:
+
+```js
+L.transform(L.branchOr(L.modifyOp(R.inc), {x: L.modifyOp(R.dec)}), {x: 0, y: 0})
+// { x: -1, y: 1 }
+```
+
+Note that [`L.branch`](#L-branch) is equivalent to `L.branchOr(L.zero)` and
+[`L.values`](#L-values) is equivalent to `L.branchOr(L.identity, {})`.
 
 #### <a id="traversals-and-combinators"></a> [≡](#contents) [▶](https://calmm-js.github.io/partial.lenses/index.html#traversals-and-combinators) Traversals and combinators
 
@@ -1876,6 +1896,9 @@ L.modify([L.rewrite(objectTo(XYZ)), L.values],
          new XYZ(1, 2, 3))
 // XYZ { x: -1, y: -2, z: -3 }
 ```
+
+Note that `L.values` is equivalent to [`L.branchOr(L.identity,
+{})`](#L-branchOr).
 
 #### <a id="folds-over-traversals"></a> [≡](#contents) [▶](https://calmm-js.github.io/partial.lenses/index.html#folds-over-traversals) Folds over traversals
 

--- a/src/ext/infestines.js
+++ b/src/ext/infestines.js
@@ -6,3 +6,7 @@ export const ltU = (x, y) => x < y
 export const gtU = (x, y) => x > y
 
 export const isInstanceOf = I.curry((Class, x) => x instanceof Class)
+
+export const create = Object.create
+export const protoless = o => I.assign(create(null), o)
+export const protoless0 = I.freeze(protoless(0))

--- a/test/tests.js
+++ b/test/tests.js
@@ -205,6 +205,7 @@ describe('arities', () => {
     assign: 3,
     assignOp: 1,
     branch: 1,
+    branchOr: 2,
     chain: 2,
     choice: 0,
     choices: 1,
@@ -1078,6 +1079,15 @@ describe('L.branch', () => {
               R.negate,
               {x: {a: 1}, y: 2})`,
     {x: {a: -1}, y: -2}
+  )
+})
+
+describe('L.branchOr', () => {
+  testEq(
+    `L.transform(L.branchOr(L.modifyOp(R.inc),
+                            {x: L.modifyOp(R.dec)}),
+                 {x: 1, y: 1})`,
+    {x: 0, y: 2}
   )
 })
 

--- a/test/types.js
+++ b/test/types.js
@@ -139,6 +139,7 @@ export const seq = T.fnVarN(0, T_optic, T_transform)
 
 // Creating new traversals
 
+export const branchOr = T.fn([T_optic, template(T_traversal)], T_traversal)
 export const branch = T.fn([template(T_traversal)], T_traversal)
 
 // Traversals and combinators


### PR DESCRIPTION
~~This changes the behaviour of `L.branch({})`, which was previously treated as a special case.~~ Actually, the old behaviour was reasonable and was based on the idea that when writing through either the `L.branch` or the `L.values` traversal, the result will be an object in case the traversal actually targets something.  So, for example, writing with `L.values` through a non-object results in the non-object and writing through `L.branch({})` is a no-op, because neither targets any elements.