### PR TITLE
Fix `flatten` and `leafs` to skip `undefined` values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Partial Lenses Changelog
 
+## 13.7.2
+
+Tightened the specification of `L.flatten` and `L.leafs` to skip `undefined`
+focuses.  This is considered a bug fix as the behaviour wasn't previously
+strictly specified.
+
 ## 13.6.2
 
 Fixed a bug in `L.filter`, which didn't correctly handle the case of writing an

--- a/README.md
+++ b/README.md
@@ -1881,7 +1881,8 @@ L.modify(L.entries, ([k, v]) => [v, k], {x: 'a', y: 'b'})
 
 `L.flatten` is a traversal over the elements of arbitrarily nested arrays.
 Other [array-like](#array-like) objects are treated as elements by `L.flatten`.
-In case the immediate target of `L.flatten` is not an array, it is traversed.
+In case the immediate target of `L.flatten` is neither `undefined` nor an array,
+it is traversed.
 
 For example:
 
@@ -1904,7 +1905,8 @@ L.modify(L.keys, R.toUpper, {x: 1, y: 2})
 ##### <a id="L-leafs"></a> [≡](#contents) [▶](https://calmm-js.github.io/partial.lenses/index.html#L-leafs) [`L.leafs ~> traversal`](#L-leafs "L.leafs: PTraversal (JSON a) a") <small><sup>v13.3.0</sup></small>
 
 `L.leafs` is a traversal that descends into ordinary arrays and plain objects
-and focuses on the elements whose constructor is neither `Array` nor `Object`.
+and focuses on non-`undefined` elements whose constructor is neither `Array` nor
+`Object`.
 
 ##### <a id="L-matches-g"></a> [≡](#contents) [▶](https://calmm-js.github.io/partial.lenses/index.html#L-matches-g) [`L.matches(/.../g) ~> traversal`](#L-matches-g "L.matches: RegExp -> PTraversal String String") <small><sup>v10.4.0</sup></small>
 

--- a/src/partial.lenses.js
+++ b/src/partial.lenses.js
@@ -1013,15 +1013,22 @@ export const values = (process.env.NODE_ENV === 'production'
   branchOr1Level(identity, I.protoless0)
 )
 
-export const children = (x, i, C, xi2yC) =>
-  I.isArray(x)
-    ? elemsI(x, i, C, xi2yC)
-    : I.isObject(x) ? values(x, i, C, xi2yC) : C.of(x)
+export const children = (process.env.NODE_ENV === 'production'
+  ? I.id
+  : C.par(2, C.ef(reqApplicative('children'))))(
+  (x, i, C, xi2yC) =>
+    I.isArray(x)
+      ? elemsI(x, i, C, xi2yC)
+      : I.isObject(x) ? values(x, i, C, xi2yC) : C.of(x)
+)
 
-export function flatten(x, i, C, xi2yC) {
-  const rec = (x, i) => (I.isArray(x) ? elemsI(x, i, C, rec) : xi2yC(x, i))
+export const flatten = (process.env.NODE_ENV === 'production'
+  ? I.id
+  : C.par(2, C.ef(reqApplicative('flatten'))))((x, i, C, xi2yC) => {
+  const rec = (x, i) =>
+    I.isArray(x) ? elemsI(x, i, C, rec) : void 0 !== x ? xi2yC(x, i) : C.of(x)
   return rec(x, i)
-}
+})
 
 export function query() {
   const r = []
@@ -1037,7 +1044,9 @@ export const satisfying = p => (x, i, C, xi2yC) => {
   return rec(x, i)
 }
 
-export const leafs = satisfying(x => !I.isArray(x) && !I.isObject(x))
+export const leafs = satisfying(
+  x => void 0 !== x && !I.isArray(x) && !I.isObject(x)
+)
 
 // Folds over traversals
 

--- a/test/tests.js
+++ b/test/tests.js
@@ -1687,6 +1687,8 @@ describe('L.flatten', () => {
     {y: 2},
     false
   ])
+  testEq(() => L.set(L.flatten, 1, undefined), undefined)
+  testEq(() => L.set(L.flatten, 1, 'defined'), 1)
 })
 
 describe('L.leafs', () => {
@@ -1698,6 +1700,8 @@ describe('L.leafs', () => {
     2,
     false
   ])
+  testEq(() => L.set(L.leafs, 1, undefined), undefined)
+  testEq(() => L.set(L.leafs, 1, 'defined'), 1)
 })
 
 describe('L.query', () => {


### PR DESCRIPTION
The behaviour of `flatten` and `leafs` when the focus is `undefined` was previously not strictly tested for.  This PR defines the behaviour of both to skip `undefined`.