### PR TITLE
Should fix bug on React Native

### DIFF
--- a/src/ext/infestines.js
+++ b/src/ext/infestines.js
@@ -9,4 +9,4 @@ export const isInstanceOf = I.curry((Class, x) => x instanceof Class)
 
 export const create = Object.create
 export const protoless = o => I.assign(create(null), o)
-export const protoless0 = I.freeze(protoless(0))
+export const protoless0 = I.freeze(protoless(I.object0))


### PR DESCRIPTION
RN doesn't allow calling Object.assign with a primitive.  This removes
that.