### PR TITLE
Loosen predicate on `uriComponent` inverse...

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Partial Lenses Changelog
 
+## 14.2.0
+
+Previously `L.uriComponent` only allowed strings to be encoded through it.  Now
+it also allows booleans and numbers similarly to e.g. Node's [Query
+String](https://nodejs.org/api/querystring.html) module.  Because this behavior
+was not previously documented or tested earlier, the change is considered a bug
+fix.
+
 ## 14.1.0
 
 Previously `L.uri`, `L.uriComponent`, and `L.json` threw an exception on invalid

--- a/src/ext/infestines.js
+++ b/src/ext/infestines.js
@@ -22,3 +22,14 @@ export const protoless = o => I.assign(create(null), o)
 export const protoless0 = I.freeze(protoless(I.object0))
 
 export const replace = I.curry((p, r, s) => s.replace(p, r))
+
+export function isPrimitiveData(x) {
+  switch (typeof x) {
+    case 'boolean':
+    case 'number':
+    case 'string':
+      return true
+    default:
+      return false
+  }
+}

--- a/src/partial.lenses.js
+++ b/src/partial.lenses.js
@@ -1846,9 +1846,9 @@ export const json = (process.env.NODE_ENV === 'production'
 
 export const uri = stringIsoU(tryCatch(decodeURI), encodeURI)
 
-export const uriComponent = stringIsoU(
-  tryCatch(decodeURIComponent),
-  encodeURIComponent
+export const uriComponent = isoU(
+  expect(I.isString, tryCatch(decodeURIComponent)),
+  expect(I.isPrimitiveData, encodeURIComponent)
 )
 
 // String isomorphisms

--- a/test/tests.js
+++ b/test/tests.js
@@ -1549,6 +1549,7 @@ describe('standard isos', () => {
     'http://www.Not a URL.com'
   )
   testEq(() => L.getInverse(L.uri, null), undefined)
+  testEq(() => L.get(L.uri, '%') instanceof Error, true)
 
   testEq(
     () => L.getInverse(L.uriComponent, 'Hello, world!'),
@@ -1556,6 +1557,9 @@ describe('standard isos', () => {
   )
   testEq(() => L.get(L.uriComponent, 'Hello%2C%20world!'), 'Hello, world!')
   testEq(() => L.getInverse(L.uriComponent, {}), undefined)
+  testEq(() => L.getInverse(L.uriComponent, 101), '101')
+  testEq(() => L.getInverse(L.uriComponent, true), 'true')
+  testEq(() => L.get(L.uriComponent, '%') instanceof Error, true)
 
   testEq(
     () => L.getInverse(L.json({space: 2}), {this: ['Is', true]}),
@@ -1565,8 +1569,6 @@ describe('standard isos', () => {
     this: ['Is', true]
   })
   testEq(() => L.getInverse(L.json(), undefined), undefined)
-  testEq(() => L.get(L.uri, '%') instanceof Error, true)
-  testEq(() => L.get(L.uriComponent, '%') instanceof Error, true)
   testEq(() => L.get(L.json(), '%') instanceof Error, true)
 })
 


### PR DESCRIPTION
...to allow not just strings, but also booleans and numbers to be encoded
directly.