### PR TITLE
Fix `subset` to skip `undefined` implicitly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Partial Lenses Changelog
 
+## 14.11.1
+
+Fixed `L.subset` not to call the predicate in case the focus is already
+`undefined`.
+
 ## 14.2.1
 
 Fixed `L.query`, `L.findWith`, and `L.orElse` (and other optics using `L.orElse`

--- a/README.md
+++ b/README.md
@@ -4185,7 +4185,8 @@ L.modify(L.identity, f, x) = f(x)
 ##### <a id="L-subset"></a> [≡](#contents) [▶](https://calmm-js.github.io/partial.lenses/index.html#L-subset) [`L.subset(maybeValue => testable) ~> isomorphism`](#L-subset "L.subset: (Maybe a -> Boolean) -> PIso a a") <small><sup>v14.3.0</sup></small>
 
 `L.subset` returns an isomorphism that acts like the identity when the data
-passes the given predicate and otherwise maps the data to `undefined`.
+passes the given predicate and otherwise maps the data to `undefined`.  The
+predicate is not called unnecessarily in case the focus is `undefined`.
 
 #### <a id="array-isomorphisms"></a> [≡](#contents) [▶](https://calmm-js.github.io/partial.lenses/index.html#array-isomorphisms) [Array isomorphisms](#array-isomorphisms)
 

--- a/src/partial.lenses.js
+++ b/src/partial.lenses.js
@@ -928,7 +928,7 @@ const crossOr = (process.env.NODE_ENV === 'production'
 
 const subsetPartial = p =>
   function subset(x) {
-    return p(x) ? x : undefined
+    return void 0 !== x && p(x) ? x : void 0
   }
 
 //

--- a/test/tests.js
+++ b/test/tests.js
@@ -2085,6 +2085,14 @@ describe('L.cross', () => {
 
 describe('L.subset', () => {
   testEq(() => L.get(L.array(L.subset(R.lt(0))), [1, -2, 3, -4]), [1, 3])
+  testEq(
+    () =>
+      L.collect([L.branches('foo', 'bar'), L.subset(R.has('x'))], {
+        foo: {x: 1},
+        baz: {x: 2}
+      }),
+    [{x: 1}]
+  )
 })
 
 describe('L.iterate', () => {


### PR DESCRIPTION
It makes no sense to call the predicate with `undefined`, because the result
will be `undefined` regardless of what the predicate returns.