### PR TITLE
Add Karet util to playground

### DIFF
--- a/docs/playground.html
+++ b/docs/playground.html
@@ -17,6 +17,7 @@
     <p>Try partial lenses above. The following libraries are available:</p>
     <ul>
       <li><code>L</code> is <a href="https://github.com/calmm-js/partial.lenses/">Partial Lenses</a></li>
+      <li><code>U</code> is <a href="https://github.com/calmm-js/karet.util/">Karet Utils</a></li>
       <li><code>R</code> is <a href="https://ramdajs.com/">Ramda</a></li>
       <li><code>_</code> is <a href="https://lodash.com/">Lodash</a></li>
     </ul>
@@ -25,6 +26,7 @@
     <script type="text/javascript" src="https://unpkg.com/babel-polyfill/dist/polyfill.min.js"></script>
     <script type="text/javascript" src="infestines.js"></script>
     <script type="text/javascript" src="partial.lenses.js"></script>
+    <script type="text/javascript" src="karet.util.js"></script>
     <script type="text/javascript" src="https://unpkg.com/lz-string/libs/lz-string.min.js"></script>
     <script type="text/javascript" src="fw/init-playground.js"></script>
     <script type="text/javascript" src="https://unpkg.com/ramda/dist/ramda.js"></script>


### PR DESCRIPTION
Add `karet util` to playground. `Karet util` is used a lot in combination with partial lenses. This way it makes it easier to try out things.